### PR TITLE
djangorestframework-simplejwt Add JWT authentication support on the backend

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,6 +13,8 @@ django-heroku = "*"
 djangorestframework = "*"
 pillow = "*"
 whitenoise = "*"
+djangorestframework-simplejwt = "*"
+django-cors-headers = "*"
 
 [requires]
 python_version = "3.7"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "9db9c8461e23e80ed27b61091990d39277e20e46a617ce5bfdd87f82f29ecf74"
+            "sha256": "d9207b766f861b8ac1927356777f74afdc0232ec0422351f08d570e68557be82"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -38,6 +38,14 @@
             "index": "pypi",
             "version": "==3.0.3"
         },
+        "django-cors-headers": {
+            "hashes": [
+                "sha256:a5960addecc04527ab26617e51b8ed42f0adab4594b24bb0f3c33e2bd3857c3f",
+                "sha256:a785b5f446f6635810776d9f5f5d23e6a2a2f728ea982648370afaf0dfdf2627"
+            ],
+            "index": "pypi",
+            "version": "==3.2.1"
+        },
         "django-heroku": {
             "hashes": [
                 "sha256:2bc690aab89eedbe01311752320a9a12e7548e3b0ed102681acc5736a41a4762",
@@ -53,6 +61,14 @@
             ],
             "index": "pypi",
             "version": "==3.11.0"
+        },
+        "djangorestframework-simplejwt": {
+            "hashes": [
+                "sha256:288ee78618d906f26abf6282b639b8f1806ce1d9a7578897a125cf79c609f259",
+                "sha256:c315be70aa12a5f5790c0ab9acd426c3a58eebea65a77d0893248c5144a5080c"
+            ],
+            "index": "pypi",
+            "version": "==4.4.0"
         },
         "gunicorn": {
             "hashes": [
@@ -108,6 +124,13 @@
             ],
             "version": "==2.8.4"
         },
+        "pyjwt": {
+            "hashes": [
+                "sha256:5c6eca3c2940464d106b99ba83b00c6add741c9becaec087fb7ccdefea71350e",
+                "sha256:8d59a976fb773f3e6a39c85636357c4f0e242707394cadadd9814f5cbaa20e96"
+            ],
+            "version": "==1.7.1"
+        },
         "pytz": {
             "hashes": [
                 "sha256:1c557d7d0e871de1f5ccd5833f60fb2550652da6be2693c1e02300743d21500d",
@@ -117,10 +140,10 @@
         },
         "sqlparse": {
             "hashes": [
-                "sha256:40afe6b8d4b1117e7dff5504d7a8ce07d9a1b15aeeade8a2d10f130a834f8177",
-                "sha256:7c3dca29c022744e95b547e867cee89f4fce4373f3549ccd8797d8eb52cdb873"
+                "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
+                "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
             ],
-            "version": "==0.3.0"
+            "version": "==0.3.1"
         },
         "whitenoise": {
             "hashes": [

--- a/server/tutvwebsite/settings/base.py
+++ b/server/tutvwebsite/settings/base.py
@@ -83,6 +83,16 @@ AUTH_PASSWORD_VALIDATORS = [
     },
 ]
 
+REST_FRAMEWORK = {
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.IsAuthenticated',
+    ),
+    'DEFAULT_AUTHENTICATION_CLASSES': (
+        'rest_framework_simplejwt.authentication.JWTAuthentication',
+        'rest_framework.authentication.SessionAuthentication',
+        'rest_framework.authentication.BasicAuthentication',
+    ),
+}
 
 # Internationalization
 # https://docs.djangoproject.com/en/2.2/topics/i18n/

--- a/server/tutvwebsite/settings/local.py
+++ b/server/tutvwebsite/settings/local.py
@@ -24,4 +24,4 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 # https://docs.djangoproject.com/en/3.0/ref/models/fields/#django.db.models.FileField.storage
 # https://docs.djangoproject.com/en/3.0/ref/models/fields/#imagefield
 
-INSTALLED_APPS = ['whitenoise.runserver_nostatic'] + INSTALLED_APPS
+# INSTALLED_APPS = ['whitenoise.runserver_nostatic'] + INSTALLED_APPS

--- a/server/tutvwebsite/settings/local.py
+++ b/server/tutvwebsite/settings/local.py
@@ -23,5 +23,3 @@ MEDIA_ROOT = os.path.join(BASE_DIR, "media")
 # TODO: set MEDIA_URL to something?
 # https://docs.djangoproject.com/en/3.0/ref/models/fields/#django.db.models.FileField.storage
 # https://docs.djangoproject.com/en/3.0/ref/models/fields/#imagefield
-
-# INSTALLED_APPS = ['whitenoise.runserver_nostatic'] + INSTALLED_APPS

--- a/server/tutvwebsite/urls.py
+++ b/server/tutvwebsite/urls.py
@@ -16,11 +16,17 @@ Including another URLconf
 
 from django.contrib import admin
 from django.urls import include, path, re_path
+from rest_framework_simplejwt.views import (
+    TokenObtainPairView,
+    TokenRefreshView,
+)
 
 import api.views as views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include('api.urls')),
+    path('token-obtain/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token-refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     re_path(r'^', views.FrontendAppView.as_view())
 ]

--- a/server/tutvwebsite/urls.py
+++ b/server/tutvwebsite/urls.py
@@ -26,7 +26,7 @@ import api.views as views
 urlpatterns = [
     path('admin/', admin.site.urls),
     path('api/v1/', include('api.urls')),
-    path('token-obtain/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('token-refresh/', TokenRefreshView.as_view(), name='token_refresh'),
+    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     re_path(r'^', views.FrontendAppView.as_view())
 ]


### PR DESCRIPTION
Closes #58 Same as issue 67 but uses djangorestframework-simplejwt instead of djangorestframework-jwt