### PR TITLE
Add Feather Icons

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "react-collapsible": "^2.7.0",
     "react-dev-utils": "^9.1.0",
     "react-dom": "^16.9.0",
+    "react-feather": "^2.0.3",
     "react-router-dom": "^5.1.2",
     "react-styleguidist": "^9.1.16",
     "react-tabs": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9197,6 +9197,13 @@ react-error-overlay@^6.0.3:
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.3.tgz#c378c4b0a21e88b2e159a3e62b2f531fd63bf60d"
   integrity sha512-bOUvMWFQVk5oz8Ded9Xb7WVdEi3QGLC8tH7HmYP0Fdp4Bn3qw0tRFmr5TW6mvahzvmrK4a6bqWGfCevBflP+Xw==
 
+react-feather@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/react-feather/-/react-feather-2.0.3.tgz#1453ff5d8c242f72b8c02846118fbd2d406375ad"
+  integrity sha512-XVjtxIyMxb2RFlqC2APoB/IZvXKDW9uLN1c264XEeZNYe8jIxjQVQpeTo3nxtHiLTgMfgf0ZYxJC6HwmY8+9BA==
+  dependencies:
+    prop-types "^15.7.2"
+
 react-group@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/react-group/-/react-group-3.0.2.tgz#cb31d0fae255111e1dace5b5f9abb9deefc7b36e"


### PR DESCRIPTION
Included `react-feather` so that we have an easy way to use icons in components. See #79 