### PR TITLE
eslint: also check non-tsx javascript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "start": "cd client && node scripts/start.js",
     "build": "cd client && node scripts/build.js",
     "test": "cd client && node scripts/test.js",
-    "eslint": "eslint \"client/src/**/*.tsx\"",
+    "eslint": "eslint \"client/src/**/*.{js,jsx,ts,tsx}\"",
     "stylelint": "stylelint \"client/src/**/*.css\"",
     "prettier-write": "prettier --write \"client/src/**/*.{tsx,css}\""
   },


### PR DESCRIPTION
Before eslint only checked files with the `.tsx` extension, which let non-markup-bearing files with the `.ts` extension (as well as potential non-typescript `.js` and `.jsx` files) slip through