### PR TITLE
Move token routes under api/v1/ prefix

### DIFF
--- a/server/tutvwebsite/urls.py
+++ b/server/tutvwebsite/urls.py
@@ -25,8 +25,8 @@ import api.views as views
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/v1/token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
+    path('api/v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     path('api/v1/', include('api.urls')),
-    path('token/', TokenObtainPairView.as_view(), name='token_obtain_pair'),
-    path('token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
     re_path(r'^', views.FrontendAppView.as_view())
 ]


### PR DESCRIPTION
This PR moves the two routes used for issuing tokens under the `api/v1` route prefix.

- `/token/` → `/api/v1/token`
- `/token/refresh/` → `/api/v1/token/refresh/`

Not having any API routes outside of this prefix allows the front-end code to be simpler and more organized, and it improves consistency
