### PR TITLE
Implement client auth flow

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
-import { StoreProvider } from './store';
+import { useStore, StoreProvider } from './store';
 import LoginShield from './components/LoginShield';
+
+import Button from './components/Button';
 
 // Components for pages of the app
 import Home from './pages/Home';
@@ -40,6 +42,16 @@ const App: React.FC = () => {
                 </li>
               </ul>
             </nav>
+
+            {React.createElement(function LogOutButton() {
+              const { dispatch } = useStore();
+              const logout = () => dispatch({ type: 'logout' });
+              return (
+                <Button variant="gray" onClick={logout}>
+                  Log out
+                </Button>
+              );
+            })}
 
             <Switch>
               <Route path="/admin/dashboard">

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
 import { StoreProvider } from './store';
+import LoginShield from './components/LoginShield';
 
 // Components for pages of the app
 import Home from './pages/Home';
@@ -15,57 +16,53 @@ const App: React.FC = () => {
   return (
     <Router>
       <StoreProvider>
-        <div className="App">
-          <nav>
-            <ul>
-              <li>
-                <Link to="/">Home</Link>
-              </li>
-              <li>
-                <Link to="/catalog">Equipment Catalog</Link>
-              </li>
-              <li>
-                <Link to="/equipmentbrowser">Equipment Browser</Link>
-              </li>
-              <li>
-                <Link to="/memberdashboard">MemberDashboard</Link>
-              </li>
-              <li>
-                <Link to="/admin/dashboard">Admin Dashboard</Link>
-              </li>
-              <li>
-                <Link to="/admin/equipment-request">Equipment Request</Link>
-              </li>
-              <li>
-                <Link to="/signin">Sign In</Link>
-              </li>
-            </ul>
-          </nav>
+        <LoginShield fallback={<SignIn />}>
+          <div className="App">
+            <nav>
+              <ul>
+                <li>
+                  <Link to="/">Home</Link>
+                </li>
+                <li>
+                  <Link to="/catalog">Equipment Catalog</Link>
+                </li>
+                <li>
+                  <Link to="/equipmentbrowser">Equipment Browser</Link>
+                </li>
+                <li>
+                  <Link to="/memberdashboard">MemberDashboard</Link>
+                </li>
+                <li>
+                  <Link to="/admin/dashboard">Admin Dashboard</Link>
+                </li>
+                <li>
+                  <Link to="/admin/equipment-request">Equipment Request</Link>
+                </li>
+              </ul>
+            </nav>
 
-          <Switch>
-            <Route path="/admin/dashboard">
-              <AdminDashboard />
-            </Route>
-            <Route path="/catalog">
-              <Catalog />
-            </Route>
-            <Route path="/equipmentbrowser">
-              <EquipmentBrowser />
-            </Route>
-            <Route path="/memberdashboard">
-              <MemberDashboard />
-            </Route>
-            <Route path="/admin/equipment-request">
-              <RequestSummary />
-            </Route>
-            <Route path="/signin">
-              <SignIn />
-            </Route>
-            <Route path="/">
-              <Home />
-            </Route>
-          </Switch>
-        </div>
+            <Switch>
+              <Route path="/admin/dashboard">
+                <AdminDashboard />
+              </Route>
+              <Route path="/catalog">
+                <Catalog />
+              </Route>
+              <Route path="/equipmentbrowser">
+                <EquipmentBrowser />
+              </Route>
+              <Route path="/memberdashboard">
+                <MemberDashboard />
+              </Route>
+              <Route path="/admin/equipment-request">
+                <RequestSummary />
+              </Route>
+              <Route path="/">
+                <Home />
+              </Route>
+            </Switch>
+          </div>
+        </LoginShield>
       </StoreProvider>
     </Router>
   );

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { BrowserRouter as Router, Switch, Route, Link } from 'react-router-dom';
 import { useStore, StoreProvider } from './store';
-import LoginShield from './components/LoginShield';
+import LoginShield from 'components/LoginShield';
 
-import Button from './components/Button';
+import Button from 'components/Button';
 
 // Components for pages of the app
 import Home from './pages/Home';

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -8,6 +8,7 @@ interface apiRequestOptions {
   headers?: any;
   body?: FormData | Blob | ArrayBuffer | string;
   addTrailingSlash?: boolean;
+  token?: string;
 }
 
 /**
@@ -60,6 +61,12 @@ export function apiReq(base: string, path: string, options: apiRequestOptions) {
   // Unless addTrailingSlash was explicitly passed as false, we make sure it's there
   if (options.addTrailingSlash !== false && !href.endsWith('/'))
     href = `${href}/`;
+  // Add access token if we have it
+  if (options.token)
+    options.headers = {
+      ...options.headers,
+      Authorization: `Bearer ${options.token}`,
+    };
 
   return fetch(href, options).then(async (r) => {
     const json = await r.json();

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -67,7 +67,11 @@ export function useApiData<T>(
   const { state } = useStore();
   const base = state && state.apiUrl;
 
-  return useSWR<T>(url, (path: string) => apiReq(base, path, options));
+  const tokenPromise = useAccessToken();
+
+  return useSWR<T>(url, (path: string) =>
+    tokenPromise.then((token) => apiReq(base, path, { token, ...options }))
+  );
 }
 
 /**
@@ -77,8 +81,10 @@ export function useApiRequest(path: string, options: apiRequestOptions = {}) {
   // Get the "base" URL from the store
   const { state } = useStore();
   const base = state && state.apiUrl;
+  const tokenPromise = useAccessToken();
   // Return a function that can be called to send the request
-  return () => apiReq(base, path, options);
+  return () =>
+    tokenPromise.then((token) => apiReq(base, path, { token, ...options }));
 }
 
 class APIError extends Error {

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -17,10 +17,10 @@ export async function getAccessToken(
   tokens: { accessToken: string | null; refreshToken: string | null },
   base: string,
   dispatch: React.Dispatch<Action>
-): Promise<string | undefined> {
+): Promise<string | null> {
   const { accessToken, refreshToken } = tokens;
   // We can't get a token if we don't have a refresh token or an access token
-  if (!accessToken && !refreshToken) return undefined;
+  if (!accessToken && !refreshToken) return null;
   // Return the token if the one we have is not expired
   const decoded: DecodedToken = jwtDecode(accessToken as string);
   if (decoded.exp > Date.now() / 1000) return accessToken as string;
@@ -39,11 +39,11 @@ export async function getAccessToken(
       return fetchedToken;
     })
     .catch((e) => {
-      // If we get an error, return undefined and log the user out
+      // If we get an error, return null and log the user out
       console.error('Error during token refresh:');
       console.log(e);
       dispatch({ type: 'logout' });
-      return undefined;
+      return null;
     });
   return newToken;
 }
@@ -53,7 +53,7 @@ interface ApiRequestOptions {
   headers?: any;
   body?: FormData | Blob | ArrayBuffer | string;
   addTrailingSlash?: boolean;
-  token?: string;
+  token?: string | null;
 }
 
 /**

--- a/client/src/api.ts
+++ b/client/src/api.ts
@@ -124,13 +124,12 @@ export const apiReq = (
   if (options.addTrailingSlash !== false && !href.endsWith('/')) {
     href = `${href}/`;
   }
-  // Add access token if we have it
-  if (options.token) {
-    options.headers = {
-      ...options.headers,
-      Authorization: `Bearer ${options.token}`,
-    };
-  }
+  // Add default headers (including access token if we have it)
+  options.headers = {
+    'Content-Type': 'application/json',
+    ...(options.token && { Authorization: `Bearer ${options.token}` }),
+    ...options.headers,
+  };
 
   return fetch(href, options).then(async (r) => {
     if (r.ok) return r.json();

--- a/client/src/components/LoginShield/LoginShield.tsx
+++ b/client/src/components/LoginShield/LoginShield.tsx
@@ -1,0 +1,18 @@
+import React, { ReactElement } from 'react';
+import { useStore } from '../../store';
+
+export function useLoginState() {
+  const { state } = useStore();
+  return state.auth.accessToken && state.auth.refreshToken;
+}
+
+interface LoginShieldProps {
+  fallback: ReactElement;
+}
+
+const LoginShield: React.FC<LoginShieldProps> = ({ children, fallback }) => {
+  const isLoggedIn = useLoginState();
+  return isLoggedIn ? (children as ReactElement) : fallback;
+};
+
+export default LoginShield;

--- a/client/src/components/LoginShield/LoginShield.tsx
+++ b/client/src/components/LoginShield/LoginShield.tsx
@@ -1,5 +1,5 @@
 import React, { ReactElement } from 'react';
-import { useStore } from '../../store';
+import { useStore } from 'store';
 
 export function useLoginState() {
   const { state } = useStore();

--- a/client/src/components/LoginShield/index.ts
+++ b/client/src/components/LoginShield/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LoginShield';

--- a/client/src/pages/SignIn/SignIn.tsx
+++ b/client/src/pages/SignIn/SignIn.tsx
@@ -17,8 +17,7 @@ const SignIn: React.FC = () => {
   });
 
   const doSignIn = (tokens: { refresh: string; access: string }) => {
-    const { refresh, access } = tokens;
-    dispatch({ type: 'login', tokens: { refresh, access } });
+    dispatch({ type: 'login', tokens });
   };
 
   const attemptSignIn = () => {

--- a/client/src/pages/SignIn/SignIn.tsx
+++ b/client/src/pages/SignIn/SignIn.tsx
@@ -8,7 +8,7 @@ import { useApiRequest } from '../../api';
 const SignIn: React.FC = () => {
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
-  const { state, dispatch } = useStore();
+  const { dispatch } = useStore();
 
   const getToken = useApiRequest('token', {
     method: 'POST',

--- a/client/src/pages/SignIn/SignIn.tsx
+++ b/client/src/pages/SignIn/SignIn.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import styles from './SignIn.module.css';
 import logo from './TUTVLogo.png';
 import Button from 'components/Button';
-import { useStore } from '../../store';
-import { useApiRequest } from '../../api';
+import { useStore } from 'store';
+import { useApiRequest } from 'api';
 
 const SignIn: React.FC = () => {
   const [username, setUsername] = React.useState('');

--- a/client/src/pages/SignIn/SignIn.tsx
+++ b/client/src/pages/SignIn/SignIn.tsx
@@ -3,14 +3,14 @@ import styles from './SignIn.module.css';
 import logo from './TUTVLogo.png';
 import Button from 'components/Button';
 import { useStore } from '../../store';
-import { useRequest } from '../../api';
+import { useApiRequest } from '../../api';
 
 const SignIn: React.FC = () => {
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
   const { state, dispatch } = useStore();
 
-  const getToken = useRequest('token', {
+  const getToken = useApiRequest('token', {
     method: 'POST',
     body: JSON.stringify({ username, password }),
     headers: { 'Content-Type': 'application/json' },

--- a/client/src/pages/SignIn/SignIn.tsx
+++ b/client/src/pages/SignIn/SignIn.tsx
@@ -2,13 +2,31 @@ import React from 'react';
 import styles from './SignIn.module.css';
 import logo from './TUTVLogo.png';
 import Button from 'components/Button';
+import { useStore } from '../../store';
+import { useRequest } from '../../api';
 
 const SignIn: React.FC = () => {
   const [username, setUsername] = React.useState('');
   const [password, setPassword] = React.useState('');
+  const { state, dispatch } = useStore();
+
+  const getToken = useRequest('token', {
+    method: 'POST',
+    body: JSON.stringify({ username, password }),
+    headers: { 'Content-Type': 'application/json' },
+  });
+
+  const doSignIn = (tokens: { refresh: string; access: string }) => {
+    const { refresh, access } = tokens;
+    dispatch({ type: 'login', tokens: { refresh, access } });
+  };
 
   const attemptSignIn = () => {
-    console.log('Username:', username, 'Password:', password);
+    getToken()
+      .then(doSignIn)
+      .catch((e) => {
+        alert(`Something went wrong: ${e.response && e.response.detail}`);
+      });
   };
 
   return (

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -37,7 +37,15 @@ const initialState: State = {
     test: 'https://tutv-dev.herokuapp.com/api/v1/',
   }[NODE_ENV],
 
-  auth: { accessToken: null, refreshToken: null },
+  // note: due to a bug, TypeScript marks code below this IIFE as "unreachable." This will be
+  // resolved in TypeScript 3.9. See https://github.com/microsoft/TypeScript/issues/36828
+  auth: (() => {
+    try {
+      return JSON.parse(localStorage.auth);
+    } catch (e) {
+      return { accessToken: null, refreshToken: null };
+    }
+  })(),
 };
 
 // Create the context
@@ -53,6 +61,7 @@ const actionHandlers: ActionDictionary = {
     } = action as LoginAction;
     state.auth.accessToken = access;
     state.auth.refreshToken = refresh;
+    localStorage.auth = JSON.stringify(state.auth);
     return state;
   },
 

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -18,7 +18,9 @@ type LoginAction = {
   tokens: { access: string; refresh: string };
 };
 
-type Action = LoginAction | { type: 'action2' };
+type LogoutAction = { type: 'logout' };
+
+type Action = LoginAction | LogoutAction;
 
 // END ACTION DEFINITIONS
 
@@ -41,7 +43,7 @@ const initialState: State = {
   // resolved in TypeScript 3.9. See https://github.com/microsoft/TypeScript/issues/36828
   auth: (() => {
     try {
-      return JSON.parse(localStorage.auth);
+      return JSON.parse(localStorage.getItem('auth') || "this isn't json");
     } catch (e) {
       return { accessToken: null, refreshToken: null };
     }
@@ -61,12 +63,14 @@ const actionHandlers: ActionDictionary = {
     } = action as LoginAction;
     state.auth.accessToken = access;
     state.auth.refreshToken = refresh;
-    localStorage.auth = JSON.stringify(state.auth);
+    localStorage.setItem('auth', JSON.stringify(state.auth));
     return state;
   },
 
-  action2(state: State): State {
-    console.log('ACTION 2');
+  logout(state: State): State {
+    state.auth.accessToken = null;
+    state.auth.refreshToken = null;
+    localStorage.removeItem('auth');
     return state;
   },
 };

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -5,9 +5,22 @@ const NODE_ENV = process.env.NODE_ENV || 'development';
 
 type State = {
   apiUrl: string;
+  auth: {
+    accessToken: string | null;
+    refreshToken: string | null;
+  };
 };
 
-type Action = { type: 'action1' } | { type: 'action2' };
+// ACTION DEFINITIONS
+
+type LoginAction = {
+  type: 'login';
+  tokens: { access: string; refresh: string };
+};
+
+type Action = LoginAction | { type: 'action2' };
+
+// END ACTION DEFINITIONS
 
 type ActionDictionary = {
   [key: string]: (state: State, action: Action) => State;
@@ -23,6 +36,8 @@ const initialState: State = {
     production: new URL('/api/v1/', window.location.origin).href,
     test: 'https://tutv-dev.herokuapp.com/api/v1/',
   }[NODE_ENV],
+
+  auth: { accessToken: null, refreshToken: null },
 };
 
 // Create the context
@@ -32,10 +47,15 @@ const StoreContext = createContext({} as StoreContext);
 // handler function here.
 // A handler function should take state as input, and return a copy of the state object mutated
 const actionHandlers: ActionDictionary = {
-  action1(state: State): State {
-    console.log('ACTION 1');
+  login(state: State, action: Action): State {
+    const {
+      tokens: { access, refresh },
+    } = action as LoginAction;
+    state.auth.accessToken = access;
+    state.auth.refreshToken = refresh;
     return state;
   },
+
   action2(state: State): State {
     console.log('ACTION 2');
     return state;

--- a/client/src/store.ts
+++ b/client/src/store.ts
@@ -20,7 +20,7 @@ type LoginAction = {
 
 type LogoutAction = { type: 'logout' };
 
-type Action = LoginAction | LogoutAction;
+export type Action = LoginAction | LogoutAction;
 
 // END ACTION DEFINITIONS
 

--- a/client/src/store.tsx
+++ b/client/src/store.tsx
@@ -58,19 +58,16 @@ const StoreContext = createContext({} as StoreContext);
 const actionHandlers: ActionDictionary = {
   login(state: State, action: Action): State {
     const {
-      tokens: { access, refresh },
+      tokens: { access: accessToken, refresh: refreshToken },
     } = action as LoginAction;
-    state.auth.accessToken = access;
-    state.auth.refreshToken = refresh;
-    localStorage.setItem('auth', JSON.stringify(state.auth));
-    return state;
+    const auth = { accessToken, refreshToken };
+    localStorage.setItem('auth', JSON.stringify(auth));
+    return { ...state, auth };
   },
 
   logout(state: State): State {
-    state.auth.accessToken = null;
-    state.auth.refreshToken = null;
     localStorage.removeItem('auth');
-    return state;
+    return { ...state, auth: { accessToken: null, refreshToken: null } };
   },
 };
 

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@babel/core": "7.6.0",
     "@svgr/webpack": "4.3.2",
     "@types/jest": "24.0.18",
+    "@types/jwt-decode": "^2.2.1",
     "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "12.7.5",
     "@types/react": "^16.9.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "@svgr/webpack": "4.3.2",
     "@types/jest": "24.0.18",
     "@types/jwt-decode": "^2.2.1",
-    "@types/lodash.clonedeep": "^4.5.6",
     "@types/node": "12.7.5",
     "@types/react": "^16.9.0",
     "@types/react-dom": "16.9.0",

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "jest-environment-jsdom-fourteen": "0.1.0",
     "jest-resolve": "24.9.0",
     "jest-watch-typeahead": "0.4.0",
+    "jwt-decode": "^2.2.0",
     "lodash.clonedeep": "^4.5.0",
     "mini-css-extract-plugin": "0.8.0",
     "optimize-css-assets-webpack-plugin": "5.0.3",

--- a/server/tutvwebsite/middleware.py
+++ b/server/tutvwebsite/middleware.py
@@ -9,8 +9,8 @@ def dev_cors_middleware(get_response):
 
     response['Access-Control-Allow-Origin'] = 'http://localhost:3000'
     response['Access-Control-Allow-Methods'] = 'GET, POST, PUT, PATCH, OPTIONS, DELETE, HEAD'
-    response['Access-Control-Allow-Headers'] = 'Content-Type, X-CSRFToken'
+    response['Access-Control-Allow-Headers'] = 'Content-Type, X-CSRFToken, Authorization'
     response['Access-Control-Allow-Credentials'] = 'true'
     return response
-  
+
   return middleware

--- a/yarn.lock
+++ b/yarn.lock
@@ -1320,6 +1320,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.3.tgz#bdfd69d61e464dcc81b25159c270d75a73c1a636"
   integrity sha512-Il2DtDVRGDcqjDtE+rF8iqg1CArehSK84HZJCT7AMITlyXRBpuPhqGLDQMowraqqu1coEaimg4ZOqggt6L6L+A==
 
+"@types/jwt-decode@^2.2.1":
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
+  integrity sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==
+
 "@types/lodash.clonedeep@^4.5.6":
   version "4.5.6"
   resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1325,18 +1325,6 @@
   resolved "https://registry.yarnpkg.com/@types/jwt-decode/-/jwt-decode-2.2.1.tgz#afdf5c527fcfccbd4009b5fd02d1e18241f2d2f2"
   integrity sha512-aWw2YTtAdT7CskFyxEX2K21/zSDStuf/ikI3yBqmwpwJF0pS+/IX5DWv+1UFffZIbruP6cnT9/LAJV1gFwAT1A==
 
-"@types/lodash.clonedeep@^4.5.6":
-  version "4.5.6"
-  resolved "https://registry.yarnpkg.com/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz#3b6c40a0affe0799a2ce823b440a6cf33571d32b"
-  integrity sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==
-  dependencies:
-    "@types/lodash" "*"
-
-"@types/lodash@*":
-  version "4.14.149"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
-  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
-
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6559,6 +6559,11 @@ jsx-ast-utils@^2.1.0, jsx-ast-utils@^2.2.1:
     array-includes "^3.0.3"
     object.assign "^4.1.0"
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+  integrity sha1-fYa9VmefWM5qhHBKZX3TkruoGnk=
+
 killable@^1.0.0, killable@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/killable/-/killable-1.0.1.tgz#4c8ce441187a061c7474fb87ca08e2a638194892"


### PR DESCRIPTION
This PR builds upon #88 and #91 to store login information in the global application store. Closes #59. 

Note: #88, #91, and #92 should be merged before this is merged.

- [x] Updates the `SignIn` page to post user credentials to the `/api/v1/token` endpoint
- [x] Redirects users off of sign in page after successful authentication
- [x] Adds `auth.accessToken` and `auth.refreshToken` to the global application store's state
- [x] Adds a `'login'` action to the global application store which mutates those pieces of state
- [x] Adds a `'logout'` action to the global application store which resets those pieces of state
- [x] Mirrors stored auth credentials in `localStorage` to persist across application reloads
- [x] Updates API functions to automatically send token credentials with requests
- [x] Updates API functions to automatically refresh expired API tokens before sending
- [x] Renders the `SignIn` page in place of any other pages whenever auth credentials are either missing or invalid and unrefreshable